### PR TITLE
Adjusting bulb brightness due to strange issue on retina displays after 1.70.0 vscode update

### DIFF
--- a/synthwave87.css
+++ b/synthwave87.css
@@ -277,7 +277,7 @@
 .codicon-lightbulb, .codicon-light-bulb  {
   /* color : #03edf9 !important; */
   color: #FF00FF !important;
-  filter: brightness(1000%) blur(1.5px) !important;
+  filter: brightness(100%) blur(1.5px) !important;
 }
 
 /* Status bar */


### PR DESCRIPTION
Adjusting bulb brightness due to strange issue on retina displays after 1.70.0 vscode update